### PR TITLE
Begin support for iOS 12.2 TV accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Field           | Required?    | Description
   manufacturer  |  *Optional*  | Manufacturer displayed in Home app.
   model         |  *Optional*  | Model displayed in Home app.
   serial        |  *Optional*  | Serial# displayed in Home app.
+**tv_service**  |  *Optional*  | Uses TV service available in iOS >12.2.
 
 ### "sources" entry
 Field           | Required?    | Description

--- a/config-sample.json
+++ b/config-sample.json
@@ -13,6 +13,7 @@
       "platform": "CEC",
       "manufacturer": "RCA",
       "model": "RTU5540-B",
+      "tv_service": true,
       "sources": [
         {
           "name": "Raspberry Pi",

--- a/index.js
+++ b/index.js
@@ -53,11 +53,16 @@ function CECPlatform(log, config) {
 
 CECPlatform.prototype = {
 	accessories: function (callback) {
-		let list = [new Power()];
-		for (let i in Config.sources) {
-			list.push(new Source(Config.sources[i]));
+		if (Config.tv_service) {
+			let tv = new Television();
+			callback(tv);
+		} else {
+			let list = [new Power()];
+			for (let i in Config.sources) {
+				list.push(new Source(Config.sources[i]));
+			}
+			callback(list);
 		}
-		callback(list);
 	}
 };
 
@@ -178,3 +183,168 @@ Source.prototype = {
 		callback();
 	}
 };
+
+function Television() {
+	this.name = Config.name || 'TV';
+	this.enabledServices = [];
+};
+
+Television.prototype = {
+	getServices: function() {
+	
+		var informationService = new Service.AccessoryInformation();
+		informationService
+			.setCharacteristic(Characteristic.Manufacturer, Config.manufacturer || 'Dominick Han')
+			.setCharacteristic(Characteristic.Model, Config.model || 'TV')
+			.setCharacteristic(Characteristic.SerialNumber, Config.serial || 'N/A');
+	
+		this.enabledServices.push(informationService);
+
+		// this.log.debug("Creating TV service for receiver %s", this.name)
+		this.tvService = new Service.Television(this.name);
+
+		this.tvService
+			.setCharacteristic(Characteristic.ConfiguredName, this.name);
+		
+		this.tvService
+			.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
+		
+		this.addSources(this.tvService)
+
+		this.tvService
+			.getCharacteristic(Characteristic.Active)
+			.on('get', this.getState.bind(this))
+			.on('set', this.setState.bind(this));
+
+		this.tvService
+			.getCharacteristic(Characteristic.On)
+			.on('get', this.getState.bind(this))
+			.on('set', this.setState.bind(this));
+
+		this.tvService
+			.getCharacteristic(Characteristic.ActiveIdentifier)
+			.on('set', this.setInputSource.bind(this))
+			.on('get', this.getInputSource.bind(this));
+		
+		// this.tvService
+		// 	.getCharacteristic(Characteristic.RemoteKey)
+		// 	.on('set', this.remoteKeyPress.bind(this));
+			
+		this.enabledServices.push(this.tvService);
+		
+		return this.enabledServices;
+	},
+
+	getState: function (callback) {
+		Log.debug('Television.getState()');
+		if (justTurnedOn) {
+			callback(null, true);
+		} else if (justTurnedOff) {
+			callback(null, false);
+		} else {
+			cec_client.stdin.write('tx 10:8f\n'); // 'pow 0'
+			let activated = false;
+			let handler = function () {
+				activated = true;
+				callback(null, true);
+			};
+			tvEvent.prependOnceListener('PowerOn', handler);
+			setTimeout(function () {
+				tvEvent.removeListener('PowerOn', handler);
+				if (!activated) {
+					callback(null, false);
+					tvEvent.emit('PowerOff');
+				}
+			}, 300);
+		}
+	},
+
+	setState: function (state, callback) {
+		Log.debug(`Television.setState(${state})`);
+		if (state === powerSwitch.getCharacteristic(Characteristic.On).value) {
+			callback();
+			this.getState(nullFunction);
+		} else {
+			let activated = false;
+			let handler = function () {
+				activated = true;
+				callback(null);
+			};
+
+			// Send on or off signal
+			cec_client.stdin.write(state ? 'tx 10:04\n' : 'tx 10:36\n');
+
+			tvEvent.prependOnceListener(state ? 'PowerOn' : 'PowerOff', handler);
+			setTimeout(function () {
+				tvEvent.removeListener(state ? 'PowerOn' : 'PowerOff', handler);
+				if (!activated) {
+					callback('TV not responding');
+				}
+			}, 15000);
+		}
+	},
+
+	addSources: function(service) {
+		Config.sources.forEach((i, x) =>  {
+			let address = i.address.replace(/\D/g,'');
+			if (address.length !== 4) {
+				throw `${config.address} is not a valid physical address!`;
+			}
+			addressSliced = address.slice(0, 2) + ':' + address.slice(2);
+
+			var inputName = i.name;
+			let tmpInput = new Service.InputSource(inputName, 'inputSource' + addressSliced);
+			tmpInput
+				.setCharacteristic(Characteristic.Identifier, addressSliced)
+				.setCharacteristic(Characteristic.ConfiguredName, inputName)
+				.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
+				.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION);
+	
+			service.addLinkedService(tmpInput);
+			this.enabledServices.push(tmpInput);
+		})
+	},
+
+	getInputSource: function (callback) {
+		Log.debug("Television.getInputSource()");
+
+		Config.sources.forEach((i, x) => {
+			let address = i.address.replace(/\D/g,'');
+			if (address.length !== 4) {
+				throw `${config.address} is not a valid physical address!`;
+			}
+			addressSliced = address.slice(0, 2) + ':' + address.slice(2);
+
+			if (addressSliced === currAddress) {
+				this.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(addressSliced);
+			}
+		})
+		
+		callback();
+		// if (powerSwitch.getCharacteristic(Characteristic.On).value && this.address === currAddress) {
+		// 	callback(null, true);
+		// } else {
+		// 	callback(null, false);
+		// }
+	},
+
+	setInputSource: function (input, callback) {
+		Log.debug(`Television.setInputSource(${input})`);
+
+		Config.sources.forEach((i, x) => {
+			let address = i.address.replace(/\D/g,'');
+			if (address.length !== 4) {
+				throw `${config.address} is not a valid physical address!`;
+			}
+			addressSliced = address.slice(0, 2) + ':' + address.slice(2);
+
+			if (addressSliced === input) {
+				cec_client.stdin.write(`tx 1f:82:${addressSliced}\n`);
+				ec_client.stdin.write(`is\n`);
+				setTimeout(() => {this.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(addressSliced);}, 500);
+			}
+		})
+		
+		callback();
+	}
+}

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ tvEvent.on('PowerOff', function () {
 
 cec_client.stdout.on('data', function (data) {
 	let traffic = data.toString();
-	Log.debug(traffic);
+	Log.info("====== Traffic:");
+	Log.info(traffic);
 	if (traffic.indexOf('<< 10:47:43:45:43') !== -1) {
 		cec_client.stdin.write('tx 10:47:52:50:69\n'); // Set OSD String to 'RPi'
 	}
@@ -54,7 +55,10 @@ function CECPlatform(log, config) {
 CECPlatform.prototype = {
 	accessories: function (callback) {
 		if (Config.tv_service) {
-			let tv = new Television();
+			Log.info("Creating Television");
+			let tv = [new Television()];
+			Log.info("++++++ TV: ");
+			Log.info(tv);
 			callback(tv);
 		} else {
 			let list = [new Power()];
@@ -191,7 +195,7 @@ function Television() {
 
 Television.prototype = {
 	getServices: function() {
-	
+		Log.info("XXXXXXXX In getServices()")
 		var informationService = new Service.AccessoryInformation();
 		informationService
 			.setCharacteristic(Characteristic.Manufacturer, Config.manufacturer || 'Dominick Han')
@@ -231,7 +235,8 @@ Television.prototype = {
 		// 	.on('set', this.remoteKeyPress.bind(this));
 			
 		this.enabledServices.push(this.tvService);
-		
+		Log.info("++++++ Enabled services:")
+		Log.info(this.enabledServices)
 		return this.enabledServices;
 	},
 
@@ -340,7 +345,7 @@ Television.prototype = {
 
 			if (addressSliced === input) {
 				cec_client.stdin.write(`tx 1f:82:${addressSliced}\n`);
-				ec_client.stdin.write(`is\n`);
+				cec_client.stdin.write(`is\n`);
 				setTimeout(() => {this.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(addressSliced);}, 500);
 			}
 		})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-hdmi-cec",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Homebridge support for TV power on/off, source selection, using HDMI-CEC",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
I was asked by some people to look into adding support for iOS 12.2's new TV accessory to this plugin. I began the work, but unfortunately my projector doesn't support CEC well so I can't fully test this. I'm open to continuing the work but would need responsive testers to debug with, assuming it doesn't just work. 😃 

You may consider merging this into another branch to test with but allow wider access and visibility.